### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,29 +1,29 @@
 {
-    "name": "Export pointclouds project in Supervisely format",
-    "type": "app",
-    "categories": [
-        "pointclouds",
-        "export"
+  "name": "Export pointclouds project in Supervisely format",
+  "type": "app",
+  "categories": [
+    "pointclouds",
+    "export"
+  ],
+  "description": "Export pointclouds project and prepares downloadable tar archive",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "modal_template": "src/modal.html",
+  "modal_template_state": {
+    "items": "True"
+  },
+  "task_location": "workspace_tasks",
+  "isolate": true,
+  "headless": true,
+  "icon": "https://user-images.githubusercontent.com/48913536/176163970-98999ba8-5922-4fc4-95c3-c9dbb19a057c.png",
+  "icon_cover": true,
+  "icon_background": "#FFFFFF",
+  "context_menu": {
+    "target": [
+      "point_cloud_project"
     ],
-    "description": "Export pointclouds project and prepares downloadable tar archive",
-    "docker_image": "supervisely/import-export:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "modal_template": "src/modal.html",
-    "modal_template_state": {
-        "items": "True"
-    },
-    "task_location": "workspace_tasks",
-    "isolate": true,
-    "headless": true,
-    "icon": "https://user-images.githubusercontent.com/48913536/176163970-98999ba8-5922-4fc4-95c3-c9dbb19a057c.png",
-    "icon_cover": true,
-    "icon_background": "#FFFFFF",
-    "context_menu": {
-        "target": [
-            "point_cloud_project"
-        ],
-        "context_root": "Download as"
-    },
-    "poster": "https://user-images.githubusercontent.com/106374579/182789054-65cb0f75-717a-49c8-a947-3fba71535250.png"
+    "context_root": "Download as"
+  },
+  "poster": "https://user-images.githubusercontent.com/106374579/182789054-65cb0f75-717a-49c8-a947-3fba71535250.png"
 }

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     ],
     "description": "Export pointclouds project and prepares downloadable tar archive",
     "docker_image": "supervisely/import-export:6.73.564",
-    "instance_version": "6.15.35",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",
     "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
     "export"
   ],
   "description": "Export pointclouds project and prepares downloadable tar archive",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
         "export"
     ],
     "description": "Export pointclouds project and prepares downloadable tar archive",
-    "docker_image": "supervisely/import-export:6.73.492",
+    "docker_image": "supervisely/import-export:6.73.564",
     "instance_version": "6.15.35",
     "main_script": "src/main.py",
     "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.492
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
